### PR TITLE
feat: implement template-driven forms and validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,43 @@
-.angular
-dist
-node_modules
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+/node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.angular/cache
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+testem.log
+/typings
+
+# e2e
+/e2e/*.js
+/e2e/*.map
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.tabSize": 2
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,3 +2,4 @@
 <a target="_blank" href="https://angular.dev/overview"> Learn more about Angular </a>
 
 <app-form-example> </app-form-example>
+<app-reg-form> </app-reg-form>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { FormExampleComponent } from './form-example/form-example.component';
+import { RegFormComponent } from './reg-form/reg-form.component';
 
 @Component({
   selector: 'app-root',
-  imports: [FormExampleComponent],
+  imports: [FormExampleComponent, RegFormComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
 })

--- a/src/app/form-example/form-example.component.html
+++ b/src/app/form-example/form-example.component.html
@@ -1,5 +1,4 @@
-<p>form-example works!</p>
-
+<h2>Template form example wuthout validation</h2>
 <form (submit)="onSubmit($event)">
   <input type="text" [(ngModel)]="user.name" name="user-name" placeholder="name" />
   <input type="text" [(ngModel)]="user.fullName" name="user-fullname" placeholder="fullName" />

--- a/src/app/reg-form/reg-form.component.css
+++ b/src/app/reg-form/reg-form.component.css
@@ -17,3 +17,7 @@
 .name-errors {
   height: 55px;
 }
+
+.email-errors {
+  height: 45px;
+}

--- a/src/app/reg-form/reg-form.component.css
+++ b/src/app/reg-form/reg-form.component.css
@@ -5,3 +5,8 @@
   margin-top: 5px;
   margin-bottom: 0;
 }
+.error-block {
+  height: 85px;
+  margin-top: 5px;
+  margin-bottom: 0;
+}

--- a/src/app/reg-form/reg-form.component.css
+++ b/src/app/reg-form/reg-form.component.css
@@ -15,5 +15,5 @@
 }
 
 .name-errors {
-  height: 55;
+  height: 55px;
 }

--- a/src/app/reg-form/reg-form.component.css
+++ b/src/app/reg-form/reg-form.component.css
@@ -6,7 +6,14 @@
   margin-bottom: 0;
 }
 .error-block {
-  height: 85px;
   margin-top: 5px;
   margin-bottom: 0;
+}
+
+.password-errors {
+  height: 85px;
+}
+
+.name-errors {
+  height: 55;
 }

--- a/src/app/reg-form/reg-form.component.css
+++ b/src/app/reg-form/reg-form.component.css
@@ -1,0 +1,7 @@
+.error {
+  color: red;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 0;
+}

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,6 +1,23 @@
 <form #form="ngForm" (submit)="onSubmit(form)">
   <div>
-    <input type="text" placeholder="First Name" name="name" required [(ngModel)]="user.name" />
+    <input
+      #firstName="ngModel"
+      appNamelidator
+      type="text"
+      placeholder="First Name"
+      name="name"
+      required
+      [(ngModel)]="user.name" />
+  </div>
+
+  <div class="error-block name-errors">
+    @if (firstName.hasError('NameValidatorDirective') && firstName.touched) {
+      @for (item of firstName.getError('NameValidatorDirective'); track item.message) {
+        <div class="error">
+          <span>* {{ item.message }}</span>
+        </div>
+      }
+    }
   </div>
   <div>
     <input type="email" placeholder="Email" name="email" required [(ngModel)]="user.email" />
@@ -15,7 +32,7 @@
       [(ngModel)]="user.password" />
   </div>
 
-  <div class="error-block">
+  <div class="error-block password-errors">
     @if (passCheck.hasError('PassValidatorDirective') && passCheck.touched) {
       @for (item of passCheck.getError('PassValidatorDirective'); track item.message) {
         <div class="error">

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,6 +1,6 @@
 <p>reg-form works!</p>
 
-<form (submit)="onSubmit($event)">
+<form #form="ngForm" (submit)="onSubmit(form)">
   <div>
     <input type="text" placeholder="First Name" name="name" required [(ngModel)]="user.name" />
   </div>
@@ -8,8 +8,18 @@
     <input type="email" placeholder="Email" name="email" required [(ngModel)]="user.email" />
   </div>
   <div>
-    <input type="password" placeholder="Password" name="password" required [(ngModel)]="user.password" />
+    <input
+      type="password"
+      #passCheck="ngModel"
+      placeholder="Password"
+      name="password"
+      required
+      appPassValidator
+      [(ngModel)]="user.password" />
   </div>
+  @if (passCheck.hasError('required') && passCheck.touched) {
+    <span class="error">* Password must be more than 6 symbols</span>
+  }
   <div>
     <button type="submit">Submit</button>
   </div>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -17,9 +17,18 @@
       appPassValidator
       [(ngModel)]="user.password" />
   </div>
+
   @if (passCheck.hasError('required') && passCheck.touched) {
-    <span class="error">* Password must be more than 6 symbols</span>
+    <span class="error">* Password must be</span>
   }
+  @if (passCheck.hasError('PassValidatorDirective') && passCheck.touched) {
+    <span class="error">* {{ passCheck.getError('PassValidatorDirective').message }}</span>
+  }
+  <span>
+    <pre>
+        PassValidatorDirective: {{ passCheck.hasError('PassValidatorDirective') }}
+    </pre>
+  </span>
   <div>
     <button type="submit">Submit</button>
   </div>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,5 +1,5 @@
 <h2>Template-driven form with validation</h2>
-<form #form="ngForm" (submit)="onSubmit(form)">
+<form #form="ngForm" (submit)="onSubmit($event, form)">
   <div>
     <input
       #firstName="ngModel"
@@ -63,20 +63,23 @@
   <div>
     <input
       type="password"
-      [(ngModel)]="confirmPassword"
+      [(ngModel)]="user.confirmPassword"
       #passConfirm="ngModel"
-      name="confirm-password"
+      name="confirmPassword"
       placeholder="Confirm Password"
       required />
   </div>
 
   <div class="error">
-    @if (passConfirm.value !== passCheck.value && passConfirm.touched) {
+    @if (passConfirm.value !== passCheck.value && passConfirm.touched && passCheck.hasError('required')) {
       <span>* Password and Confirm Password must be equal</span>
     }
   </div>
 
   <div>
-    <button type="submit">Submit</button>
+    <span>{{ form.invalid }}</span>
+  </div>
+  <div>
+    <button type="submit" [disabled]="form.invalid || passConfirm.value !== passCheck.value">Submit</button>
   </div>
 </form>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,5 +1,3 @@
-<p>reg-form works!</p>
-
 <form #form="ngForm" (submit)="onSubmit(form)">
   <div>
     <input type="text" placeholder="First Name" name="name" required [(ngModel)]="user.name" />
@@ -18,17 +16,14 @@
       [(ngModel)]="user.password" />
   </div>
 
-  @if (passCheck.hasError('required') && passCheck.touched) {
-    <span class="error">* Password must be</span>
-  }
-  @if (passCheck.hasError('PassValidatorDirective') && passCheck.touched) {
-    <span class="error">* {{ passCheck.getError('PassValidatorDirective').message }}</span>
-  }
-  <span>
-    <pre>
-        PassValidatorDirective: {{ passCheck.hasError('PassValidatorDirective') }}
-    </pre>
-  </span>
+  <div class="error-block">
+    <div *ngIf="passCheck.hasError('PassValidatorDirective') && passCheck.touched">
+      <div *ngFor="let item of passCheck.getError('PassValidatorDirective'); trackBy: trackByFn">
+        <div class="error">* {{ item.message }}</div>
+      </div>
+    </div>
+  </div>
+
   <div>
     <button type="submit">Submit</button>
   </div>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,0 +1,16 @@
+<p>reg-form works!</p>
+
+<form (submit)="onSubmit($event)">
+  <div>
+    <input type="text" placeholder="First Name" name="name" required [(ngModel)]="user.name" />
+  </div>
+  <div>
+    <input type="email" placeholder="Email" name="email" required [(ngModel)]="user.email" />
+  </div>
+  <div>
+    <input type="password" placeholder="Password" name="password" required [(ngModel)]="user.password" />
+  </div>
+  <div>
+    <button type="submit">Submit</button>
+  </div>
+</form>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -1,3 +1,4 @@
+<h2>Template-driven form with validation</h2>
 <form #form="ngForm" (submit)="onSubmit(form)">
   <div>
     <input
@@ -19,8 +20,25 @@
       }
     }
   </div>
+
   <div>
-    <input type="email" placeholder="Email" name="email" required [(ngModel)]="user.email" />
+    <input
+      appEmailValidator
+      #email="ngModel"
+      type="email"
+      placeholder="Email"
+      name="email"
+      required
+      [(ngModel)]="user.email" />
+  </div>
+  <div class="error-block email-errors">
+    @if (email.hasError('EmailValidatorDirective') && email.touched) {
+      @for (item of email.getError('EmailValidatorDirective'); track item.message) {
+        <div class="error">
+          <span>* {{ item.message }}</span>
+        </div>
+      }
+    }
   </div>
   <div>
     <input

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -17,11 +17,11 @@
   </div>
 
   <div class="error-block">
-    <div *ngIf="passCheck.hasError('PassValidatorDirective') && passCheck.touched">
-      <div *ngFor="let item of passCheck.getError('PassValidatorDirective'); trackBy: trackByFn">
+    @if (passCheck.hasError('PassValidatorDirective') && passCheck.touched) {
+      @for (item of passCheck.getError('PassValidatorDirective'); track item.message) {
         <div class="error">* {{ item.message }}</div>
-      </div>
-    </div>
+      }
+    }
   </div>
 
   <div>

--- a/src/app/reg-form/reg-form.component.html
+++ b/src/app/reg-form/reg-form.component.html
@@ -11,7 +11,6 @@
       #passCheck="ngModel"
       placeholder="Password"
       name="password"
-      required
       appPassValidator
       [(ngModel)]="user.password" />
   </div>
@@ -19,8 +18,26 @@
   <div class="error-block">
     @if (passCheck.hasError('PassValidatorDirective') && passCheck.touched) {
       @for (item of passCheck.getError('PassValidatorDirective'); track item.message) {
-        <div class="error">* {{ item.message }}</div>
+        <div class="error">
+          <span> * {{ item.message }} </span>
+        </div>
       }
+    }
+  </div>
+
+  <div>
+    <input
+      type="password"
+      [(ngModel)]="confirmPassword"
+      #passConfirm="ngModel"
+      name="confirm-password"
+      placeholder="Confirm Password"
+      required />
+  </div>
+
+  <div class="error">
+    @if (passConfirm.value !== passCheck.value && passConfirm.touched) {
+      <span>* Password and Confirm Password must be equal</span>
     }
   </div>
 

--- a/src/app/reg-form/reg-form.component.spec.ts
+++ b/src/app/reg-form/reg-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegFormComponent } from './reg-form.component';
+
+describe('RegFormComponent', () => {
+  let component: RegFormComponent;
+  let fixture: ComponentFixture<RegFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegFormComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -16,6 +16,7 @@ export class RegFormComponent {
     lastName: '',
     password: '',
   };
+  confirmPassword = '';
 
   // onSubmit(form: SubmitEvent): void {
   //   console.log('You submitted value:', form);

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -2,10 +2,11 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { PassValidatorDirective } from '../share/directives/pass-validator.directive';
+import { NameValidatorDirective } from '../share/directives/name-validator.directive';
 
 @Component({
   selector: 'app-reg-form',
-  imports: [CommonModule, FormsModule, PassValidatorDirective],
+  imports: [CommonModule, FormsModule, PassValidatorDirective, NameValidatorDirective],
   templateUrl: './reg-form.component.html',
   styleUrl: './reg-form.component.css',
 })

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -17,19 +17,31 @@ export class RegFormComponent {
     email: '',
     lastName: '',
     password: '',
+    confirmPassword: '',
   };
-  confirmPassword = '';
+
+  // It.s important for different reasons testing.
+
+  // confirmPassword = '';
 
   // onSubmit(form: SubmitEvent): void {
   //   console.log('You submitted value:', form);
   //   // @ts-expect-error: ng is not defined
   //   console.log(window.ng.getDirectives(form.target));
   // }
-  onSubmit(form: NgForm): void {
-    console.log('You submitted value:', form);
+  // asdA123!
+  onSubmit(event: Event, form: NgForm): void {
+    event.preventDefault(); // Prevent default action for the submit event;
+    // console.log('You submitted value:', form);
+
+    // That is the way to get the value of the form. And separate the password and confirmPassword.
+    const { confirmPassword, password, ...restForm } = form.value;
+    console.log('confirmPassword: ', confirmPassword);
+    console.log('password: ', password);
+    console.log('restForm: ', restForm);
   }
 
-  trackByFn(index: number, item: { message: string }): string {
-    return item.message;
-  }
+  // trackByFn(index: number, item: { message: string }): string {
+  //   return item.message;
+  // }
 }

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -25,4 +25,8 @@ export class RegFormComponent {
   onSubmit(form: NgForm): void {
     console.log('You submitted value:', form);
   }
+
+  trackByFn(index: number, item: { message: string }): string {
+    return item.message;
+  }
 }

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -3,10 +3,11 @@ import { Component } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { PassValidatorDirective } from '../share/directives/pass-validator.directive';
 import { NameValidatorDirective } from '../share/directives/name-validator.directive';
+import { EmailValidatorDirective } from '../share/directives/email-validator.directive';
 
 @Component({
   selector: 'app-reg-form',
-  imports: [CommonModule, FormsModule, PassValidatorDirective, NameValidatorDirective],
+  imports: [CommonModule, FormsModule, PassValidatorDirective, NameValidatorDirective, EmailValidatorDirective],
   templateUrl: './reg-form.component.html',
   styleUrl: './reg-form.component.css',
 })

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-reg-form',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './reg-form.component.html',
+  styleUrl: './reg-form.component.css'
+})
+export class RegFormComponent {
+  user = {
+    name: '',
+    email: '',
+    lastName: '',
+    password: '',
+  }
+
+  onSubmit(form: SubmitEvent): void {
+    console.log('You submitted value:', form);
+  }
+
+}

--- a/src/app/reg-form/reg-form.component.ts
+++ b/src/app/reg-form/reg-form.component.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
+import { PassValidatorDirective } from '../share/directives/pass-validator.directive';
 
 @Component({
   selector: 'app-reg-form',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PassValidatorDirective],
   templateUrl: './reg-form.component.html',
-  styleUrl: './reg-form.component.css'
+  styleUrl: './reg-form.component.css',
 })
 export class RegFormComponent {
   user = {
@@ -14,10 +15,14 @@ export class RegFormComponent {
     email: '',
     lastName: '',
     password: '',
-  }
+  };
 
-  onSubmit(form: SubmitEvent): void {
+  // onSubmit(form: SubmitEvent): void {
+  //   console.log('You submitted value:', form);
+  //   // @ts-expect-error: ng is not defined
+  //   console.log(window.ng.getDirectives(form.target));
+  // }
+  onSubmit(form: NgForm): void {
     console.log('You submitted value:', form);
   }
-
 }

--- a/src/app/share/directives/email-checker.ts
+++ b/src/app/share/directives/email-checker.ts
@@ -1,0 +1,86 @@
+const MAX_LOCAL_PART_LENGTH = 45;
+const MIN_LOCAL_PART_LENGTH = 2;
+const MAX_DOMAIN_LENGTH = 85;
+const MIN_DOMAIN_LENGTH = 5;
+const MIN_FIRST_LEVEL_DOMAIN_LENGTH = 3;
+const MIN_TOP_LEVEL_DOMAIN_LENGTH = 2;
+const AT_SYMBOL_MESSAGE = 'Email must contain one @ symbol';
+const SPELL_PART_MESSAGE =
+  'Only letters, numbers, and special characters may be used in the email.s sections., _, - and it must have the correct length.';
+
+import { AbstractControl } from '@angular/forms';
+
+export class EmailChecker {
+  static checkAtSymbols(control: AbstractControl): boolean {
+    if (!control.value) return false;
+    const atArray = control.value.split('@');
+    return atArray.length === 2;
+  }
+
+  static checkLocalPart(control: AbstractControl): boolean {
+    if (!control.value) return false;
+    const atArray = control.value.split('@');
+    const localPart = atArray[0];
+    /* The pattern '^[a-zA-Z0-9._-]+$' is used to define:
+      ^ asserts the position at the start of the string.
+      [a-zA-Z0-9._-] specifies a character class that matches any single alphanumeric character (both uppercase and lowercase), 
+        as well as the special characters ., _, and -.
+      + is a quantifier that means "one or more" of the preceding element.
+      $ asserts the position at the end of the string.
+    */
+    const regexp = new RegExp('^[a-zA-Z0-9._-]+$');
+    const checkLocalPart = regexp.test(localPart);
+
+    const checkLength = localPart.length >= MIN_LOCAL_PART_LENGTH && localPart.length <= MAX_LOCAL_PART_LENGTH;
+    return checkLength && checkLocalPart;
+  }
+
+  static checkDomain(control: AbstractControl): boolean {
+    if (!control.value) return false;
+    const atArray = control.value.split('@');
+    const domain = atArray[1];
+    if (!domain) return false;
+    /* The pattern '^[a-zA-Z0-9.-]+$' is used to define:
+      ^ asserts the position at the start of the string.
+      [a-zA-Z0-9.-] specifies a character class that matches any single alphanumeric character (both uppercase and lowercase), 
+        as well as the special characters . and -.
+      + is a quantifier that means "one or more" of the preceding element.
+      $ asserts the position at the end of the string.
+    */
+    const regexp = new RegExp('^[a-zA-Z0-9.-]+$');
+    const checkDomainSpelling = regexp.test(domain);
+
+    // Split the domain at the last dot to separate the domain and top-level domain
+    const lastDotIndex = domain.lastIndexOf('.');
+    if (
+      lastDotIndex === -1 &&
+      lastDotIndex < MIN_TOP_LEVEL_DOMAIN_LENGTH &&
+      domain.length - lastDotIndex < MIN_FIRST_LEVEL_DOMAIN_LENGTH
+    )
+      return false;
+
+    const checkLengthDomen = domain.length >= MIN_DOMAIN_LENGTH && domain.length <= MAX_DOMAIN_LENGTH;
+    // NO NEEDED
+
+    // const topLevelDomain = domain.split('.');
+    // if (!topLevelDomain[1]) return false;
+    // const checkLengthTopLevelDomain =
+    //   topLevelDomain[1].length >= MIN_TOP_LEVEL_DOMAIN_LENGTH &&
+    //   topLevelDomain[1].length <= MAX_TOP_LEVEL_DOMAIN_LENGTH;
+
+    // return checkLengthDomen && checkDomainSpelling && checkLengthTopLevelDomain;
+    return checkLengthDomen && checkDomainSpelling;
+  }
+
+  static allEmailChecks(control: AbstractControl): object[] | null {
+    const messages: object[] = [];
+    if (!EmailChecker.checkAtSymbols(control)) {
+      messages.push({ message: AT_SYMBOL_MESSAGE });
+    }
+    if (!EmailChecker.checkLocalPart(control) || !EmailChecker.checkDomain(control)) {
+      messages.push({ message: SPELL_PART_MESSAGE });
+    }
+
+    return messages;
+  }
+}

--- a/src/app/share/directives/email-validator.directive.ts
+++ b/src/app/share/directives/email-validator.directive.ts
@@ -1,0 +1,24 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { EmailChecker } from './email-checker';
+
+@Directive({
+  selector: '[appEmailValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: EmailValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class EmailValidatorDirective implements Validator {
+  change!: () => void;
+  validate(control: AbstractControl): ValidationErrors | null {
+    const checker = EmailChecker.allEmailChecks(control);
+    return String(checker) === '' ? null : { EmailValidatorDirective: checker };
+  }
+  registerOnValidatorChange?(fn: () => void): void {
+    this.change = fn;
+  }
+}

--- a/src/app/share/directives/name-checker.ts
+++ b/src/app/share/directives/name-checker.ts
@@ -1,0 +1,38 @@
+import { AbstractControl } from '@angular/forms';
+
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 20;
+const NAME_REQUIRED_MESSAGE = 'Name is required';
+const NAME_LENGTH_MESSAGE = 'Name there must be a minimum of 2 and a maximum of 20 symbols.';
+const NAME_LATIN_MESSAGE = 'The first letter in the name must be capitalized, name must contain only latin letters';
+
+export class NameValidator {
+  static requireCheck(control: AbstractControl): boolean {
+    return control.value ? true : false;
+  }
+
+  static lengthCheck(control: AbstractControl): boolean {
+    if (!control.value) return false;
+    const check = control.value.length > MIN_NAME_LENGTH && control.value.length < MAX_NAME_LENGTH;
+    return check ? true : false;
+  }
+  /* Explanation of the updated regular expression:
+      ^[A-Z] asserts that the string starts with an uppercase letter.
+      [a-z]+$ asserts that the rest of the string consists of one or more lowercase letters and ends at the end of the string
+  */
+  static latinCheck(control: AbstractControl): boolean | null {
+    const regex = new RegExp('^[A-Z][a-z]+$');
+    return regex.test(control.value) ? true : false;
+  }
+
+  static allNameChecks(control: AbstractControl): object[] {
+    const errorList: object[] = [];
+    if (!NameValidator.requireCheck(control)) {
+      errorList.push({ message: NAME_REQUIRED_MESSAGE });
+    }
+    if (!NameValidator.lengthCheck(control)) errorList.push({ message: NAME_LENGTH_MESSAGE });
+    if (!NameValidator.latinCheck(control)) errorList.push({ message: NAME_LATIN_MESSAGE });
+
+    return errorList;
+  }
+}

--- a/src/app/share/directives/name-validator.directive.ts
+++ b/src/app/share/directives/name-validator.directive.ts
@@ -1,0 +1,26 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NameValidator } from './name-checker';
+
+@Directive({
+  selector: '[appNamelidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: NameValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class NameValidatorDirective implements Validator {
+  change!: () => void;
+  validate(control: AbstractControl): ValidationErrors | null {
+    // this.change();
+    const messages = NameValidator.allNameChecks(control);
+
+    return String(messages) === '' ? null : { NameValidatorDirective: messages };
+  }
+  registerOnValidatorChange?(fn: () => void): void {
+    this.change = fn;
+  }
+}

--- a/src/app/share/directives/pass-checker.ts
+++ b/src/app/share/directives/pass-checker.ts
@@ -1,0 +1,79 @@
+import { AbstractControl } from '@angular/forms';
+
+const PASSWORD_LENTGH = 6;
+const PASSWORD_REQUIRED_MESSAGE = 'Password is required';
+const PASSWORD_LENTGH_MESSAGE = 'Password must contain at least 6 symbols';
+const PASSWORD_NUMBER_MESSAGE = 'Password must contain at least one number';
+const PASSWORD_MIX_LETTER_MESSAGE = 'Password must contain at least one uppercase and one lowercase letter';
+const PASSWORD_SPECIAL_CHAR_MESSAGE = 'Password must contain at least one special character';
+
+export class PassChecker {
+  static requiredChecker(control: AbstractControl): boolean {
+    return control.value === null || control.value.length > 0;
+  }
+
+  static lengthChecker(control: AbstractControl): boolean {
+    return control.value.length >= PASSWORD_LENTGH;
+  }
+
+  static numberChecker(control: AbstractControl): boolean {
+    // that checks whether the input string contains at least one numeric digit.
+    // [0-9] specifies a character class that matches any single digit from 0 to 9.
+    // + is a quantifier that means "one or more" of the preceding element. Therefore, [0-9]+ matches one or more consecutive digits.
+    const regexp = new RegExp('[0-9]+');
+    return regexp.test(control.value);
+  }
+
+  static mixLetterChecker(control: AbstractControl): boolean {
+    // that checks whether the input string contains at least one uppercase letter and one lowercase letter.
+    // [A-Z] specifies a character class that matches any uppercase letter from A to Z.
+    // [a-z] specifies a character class that matches any lowercase letter from a to z.
+    // /^(?=.*[a-z])(?=.*[A-Z])/ is a regular expression pattern. In this pattern:
+
+    // ^ asserts the position at the start of the string.
+    // (?=.*[a-z]) is a positive lookahead assertion that checks for the presence of at least one lowercase letter anywhere in the string. Specifically:
+    // .* matches any character (except for line terminators) zero or more times.
+    // [a-z] specifies a character class that matches any single lowercase letter from 'a' to 'z'.
+    const regexp = new RegExp('^(?=.*[a-z])(?=.*[A-Z])');
+    return regexp.test(control.value);
+  }
+
+  static specialCharChecker(control: AbstractControl): boolean {
+    // that checks whether the input string contains at least one special character.
+    // \W specifies a character class that matches any non-word character.
+    // \W+ is a regular expression pattern that matches one or more consecutive non-word characters.
+    const regexp = new RegExp('\\W+');
+    return regexp.test(control.value);
+  }
+
+  static allPassChecks(control: AbstractControl): object[] {
+    const errorsList: object[] = [];
+
+    if (!control.value) {
+      errorsList.push({ message: PASSWORD_REQUIRED_MESSAGE });
+      return errorsList;
+    }
+
+    if (!PassChecker.requiredChecker(control)) {
+      errorsList.push({ message: PASSWORD_REQUIRED_MESSAGE });
+    }
+
+    if (!PassChecker.lengthChecker(control)) {
+      errorsList.push({ message: PASSWORD_LENTGH_MESSAGE });
+    }
+
+    if (!PassChecker.numberChecker(control)) {
+      errorsList.push({ message: PASSWORD_NUMBER_MESSAGE });
+    }
+
+    if (!PassChecker.mixLetterChecker(control)) {
+      errorsList.push({ message: PASSWORD_MIX_LETTER_MESSAGE });
+    }
+
+    if (!PassChecker.specialCharChecker(control)) {
+      errorsList.push({ message: PASSWORD_SPECIAL_CHAR_MESSAGE });
+    }
+
+    return errorsList;
+  }
+}

--- a/src/app/share/directives/pass-validator.directive.spec.ts
+++ b/src/app/share/directives/pass-validator.directive.spec.ts
@@ -1,0 +1,8 @@
+import { PassValidatorDirective } from './pass-validator.directive';
+
+describe('PassValidatorDirective', () => {
+  it('should create an instance', () => {
+    const directive = new PassValidatorDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/share/directives/pass-validator.directive.ts
+++ b/src/app/share/directives/pass-validator.directive.ts
@@ -1,0 +1,28 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+@Directive({
+  selector: '[appPassValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: PassValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class PassValidatorDirective implements Validator {
+  change!: () => void;
+
+  // constructor() { }
+  validate(control: AbstractControl): ValidationErrors | null {
+    // throw new Error('Method not implemented.');
+    console.log('control:', control);
+    // this.change();
+    return null;
+  }
+  registerOnValidatorChange?(fn: () => void): void {
+    // throw new Error('Method not implemented.');
+    this.change = fn;
+  }
+}

--- a/src/app/share/directives/pass-validator.directive.ts
+++ b/src/app/share/directives/pass-validator.directive.ts
@@ -17,9 +17,12 @@ export class PassValidatorDirective implements Validator {
   // constructor() { }
   validate(control: AbstractControl): ValidationErrors | null {
     // throw new Error('Method not implemented.');
-    console.log('control:', control);
+    console.log('control:', control.value);
+    console.log('control length:', control.value?.length);
     // this.change();
-    return null;
+    return control.value?.length >= 6
+      ? null
+      : { PassValidatorDirective: { message: 'Password must contain at least 6 symbols' } };
   }
   registerOnValidatorChange?(fn: () => void): void {
     // throw new Error('Method not implemented.');

--- a/src/app/share/directives/pass-validator.directive.ts
+++ b/src/app/share/directives/pass-validator.directive.ts
@@ -16,15 +16,11 @@ export class PassValidatorDirective implements Validator {
   change!: () => void;
 
   validate(control: AbstractControl): ValidationErrors | null {
-    console.log('control:', control.value);
-    // console.log('control length:', control.value?.length);
     const messages = PassChecker.allPassChecks(control);
-    console.log('control messages:', messages);
     // this.change();
-    return control.value?.length >= 6 ? null : { PassValidatorDirective: { messages } };
+    return String(messages) === '' ? null : { PassValidatorDirective: messages };
   }
   registerOnValidatorChange?(fn: () => void): void {
-    // throw new Error('Method not implemented.');
     this.change = fn;
   }
 }

--- a/src/app/share/directives/pass-validator.directive.ts
+++ b/src/app/share/directives/pass-validator.directive.ts
@@ -1,5 +1,6 @@
 import { Directive } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { PassChecker } from './pass-checker';
 
 @Directive({
   selector: '[appPassValidator]',
@@ -14,15 +15,13 @@ import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@an
 export class PassValidatorDirective implements Validator {
   change!: () => void;
 
-  // constructor() { }
   validate(control: AbstractControl): ValidationErrors | null {
-    // throw new Error('Method not implemented.');
     console.log('control:', control.value);
-    console.log('control length:', control.value?.length);
+    // console.log('control length:', control.value?.length);
+    const messages = PassChecker.allPassChecks(control);
+    console.log('control messages:', messages);
     // this.change();
-    return control.value?.length >= 6
-      ? null
-      : { PassValidatorDirective: { message: 'Password must contain at least 6 symbols' } };
+    return control.value?.length >= 6 ? null : { PassValidatorDirective: { messages } };
   }
   registerOnValidatorChange?(fn: () => void): void {
     // throw new Error('Method not implemented.');


### PR DESCRIPTION
1. Task: Create some validators in a template-driven form as a directive.
2. Screenshot:
![image](https://github.com/user-attachments/assets/b15808d8-9e04-480e-8ec6-fa6d86557349)
4. Deploy: [link](https://github.com/)
5. Done 21.12.2024 / deadline 31.12.2024
6. Feature:
- [x]  Implementing a template-driven form without validation
- [x]  Implementing a template-driven form with validation
- [x] Implementing a password validator using a directive,
- [x] Implementing a name validator using a directive,
- [x] Implementing an email validator using a directive,
- [x] Implementing the disabling "Submit" button and preventDefault the form,
  